### PR TITLE
Wrap addons in realpath

### DIFF
--- a/src/RepeaterFieldTypeServiceProvider.php
+++ b/src/RepeaterFieldTypeServiceProvider.php
@@ -39,7 +39,7 @@ class RepeaterFieldTypeServiceProvider extends AddonServiceProvider
         //$breadcrumb->add('anomaly.module.repeaters::addon.name', 'admin/repeaters');
 
         $addon = $integrator->register(
-            __DIR__ . '/../addons/anomaly/repeaters-module/',
+            realpath(__DIR__ . '/../addons/anomaly/repeaters-module/'),
             'anomaly.module.repeaters',
             true,
             true
@@ -52,7 +52,7 @@ class RepeaterFieldTypeServiceProvider extends AddonServiceProvider
 //            $breadcrumb->add('anomaly.module.repeaters::addon.name', 'admin/repeaters');
 //
 //            $integrator->register(
-//                __DIR__ . '/../addons/anomaly/repeaters-module/',
+//                realpath(__DIR__ . '/../addons/anomaly/repeaters-module/'),
 //                'anomaly.module.repeaters',
 //                true,
 //                true


### PR DESCRIPTION
If you don't wrap this in realpath the relative path blows up when trying to include assets in the addon.  This issue started in 3.3.  Realpath translates the relative path and allows assets to be included from the addon just fine.