### PR TITLE
ReadOnly Support For Repeater Fields

### DIFF
--- a/resources/views/input.twig
+++ b/resources/views/input.twig
@@ -13,6 +13,7 @@
         {% endfor %}
     </div>
 
+    {% if (field_type.readonly == 0) %}
     <div class="repeater-controls">
 
         <a href="{{ url('admin/repeater-field_type/form/' ~ field_type.id() ~ '?prefix=' ~ field_type.prefix) }}"
@@ -30,5 +31,6 @@
         {% endif %}
 
     </div>
+    {% endif %}
 
 </div>

--- a/resources/views/partials/controls.twig
+++ b/resources/views/partials/controls.twig
@@ -1,10 +1,12 @@
 <div class="repeater-item-controls">
     <ul class="list-inline">
+        {% if (field_type.readonly == 0) %}
         <li class="list-inline-item">
             <a href="#" class="repeater-handle" onclick="return false;">
                 <i class="fa fa-arrows"></i>
             </a>
         </li>
+        {% endif %}
         <li class="list-inline-item">
             {{ field_type.placeholder }}
         </li>
@@ -20,11 +22,13 @@
                data-collapse="{{ trans('anomaly.field_type.repeater::input.collapse') }}">
                 {{ icon('fa fa-compress') }} <span>{{ trans('anomaly.field_type.repeater::input.collapse') }}</span>
             </a>
+            {% if (field_type.readonly == 0) %}
             <div class="dropdown-divider"></div>
             <a href="#" class="dropdown-item text-danger"
                onclick="$(this).closest('.repeater-item').remove(); return false;">
                 <i class="fa fa-trash"></i> <span>{{ trans('anomaly.field_type.repeater::input.delete') }}</span>
             </a>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/src/Command/GetMultiformFromData.php
+++ b/src/Command/GetMultiformFromData.php
@@ -65,6 +65,8 @@ class GetMultiformFromData
             if ($item['entry']) {
                 $form->setEntry($item['entry']);
             }
+            
+            $form->setReadOnly($this->fieldType->isReadOnly());
 
             $forms->addForm($this->fieldType->getFieldName() . '_' . $item['instance'], $form);
         }

--- a/src/Command/GetMultiformFromPost.php
+++ b/src/Command/GetMultiformFromPost.php
@@ -69,6 +69,9 @@ class GetMultiformFromPost
             } catch(\Exception $e) {
                 dd($item);
             }
+            
+            $form->setReadOnly($this->fieldType->isReadOnly());
+            
             $forms->addForm($this->fieldType->getFieldName() . '_' . $item['instance'], $form);
         }
 

--- a/src/Command/GetMultiformFromRelation.php
+++ b/src/Command/GetMultiformFromRelation.php
@@ -62,6 +62,8 @@ class GetMultiformFromRelation
             $type->setPrefix($this->fieldType->getPrefix());
 
             $form = $type->form($field, $instance)->setEntry($entry->getId());
+            
+            $form->setReadOnly($this->fieldType->isReadOnly());
 
             $forms->addForm($this->fieldType->getFieldName() . '_' . $instance, $form);
         }


### PR DESCRIPTION
Add support for readonly to repeater fields. Parent fields / forms set as read only will correctly stop editing of current repeater fields, and disables the rearrange, delete and add row on each repeater.