### PR TITLE
Fix for pulling wrong form

### DIFF
--- a/src/RepeaterFieldType.php
+++ b/src/RepeaterFieldType.php
@@ -254,10 +254,8 @@ class RepeaterFieldType extends FieldType
      */
     public function form(FieldInterface $field, $instance = null)
     {
-        /* @var StreamInterface $stream */
         /* @var EntryInterface $model */
-        $stream = $this->getRelatedStream();
-        $model  = $stream->getEntryModel();
+        $model = $this->getRelatedModel();
 
         /* @var FormBuilder $builder */
         $builder = $model->newRepeaterFieldTypeFormBuilder()


### PR DESCRIPTION
Fix the repeater from pulling the wrong model, and hence the wrong form when building the multiform.

This allows for the custom forms to have there own handling and validations vs always just pulling the base form.